### PR TITLE
API Endpoint: Join game

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is the server side of the Codewords game. It manages game state and handles
 ### API Endpoints
 
 - [Create/Initiate Game](#create_game)
+- [Join Existing Game](#join_game)
 
 #### Create Game
 
@@ -63,13 +64,96 @@ HTTP/1.1 201 Created
 <details><summary>Failed Responses</summary>
 
 ##### Name Omitted
-This error occurs if the body of the request does not contain a `name`, or if the `name` is empty. 
+This error occurs if the body of the request does not contain a `name`, or if the `name` is empty.
 ```http
 HTTP/1.1 401 Unauthorized
 ```
 ```js
 {
   "error": "You must provide a username"
+}
+```
+
+</details>
+
+#### Join Game
+
+Request that the server create a new Player instance for the requesting user and attach it to the Game denoted by the invite code.
+
+##### Request
+```http
+POST /api/v1/games/:invite_code/players
+```
+```js
+{
+  "name": "Lana"
+}
+```
+|key|description|
+|:---:|:--- |
+|`:invite_code`| (Within URI) The invite code provided by the person inviting the requesting user to their existing game.|
+|`name`|The username that the requesting user would like to use during the game|
+
+##### Successful Response
+```http
+HTTP/1.1 200 OK
+```
+```js
+{
+  "game_channel": "game_9aZReVkGAotVahGLS88vEnYw",
+  "name": "Lana",
+  "token": "uuxHQc7djqQuzWgJxAp5r1vy"
+}
+```
+|key|description|
+|:---:|:--- |
+|`game_channel`|The Websockets channel that players will connect to for game-wide data updates.|
+|`name`|A confirmation that the requested name was indeed assigned to the player.|
+|`token`|A token unique to the current player, which can be used to identify them in future requests to the server.|
+
+<details><summary>Failed Responses</summary>
+
+##### Name Omitted
+This error occurs if the body of the request does not contain a `name`, or if the `name` is empty.
+```http
+HTTP/1.1 401 Unauthorized
+```
+```js
+{
+  "error": "You must provide a username"
+}
+```
+
+##### Name Already In Use
+This error occurs if the `name` requested by the user is already in use by another Player in this game.
+```http
+HTTP/1.1 401 Unauthorized
+```
+```js
+{
+  "error": "That username is already taken"
+}
+```
+
+##### Invalid Invite Code
+This error occurs if the invite code provided by the user does not match a current game.
+```http
+HTTP/1.1 401 Unauthorized
+```
+```js
+{
+  "error": "That invite code is invalid"
+}
+```
+
+##### Game Is Full
+This error occurs if the invite code provided for the user matches a game that does not have room for additional players.
+```http
+HTTP/1.1 401 Unauthorized
+```
+```js
+{
+  "error": "That game is already full"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ This is the server side of the Codewords game. It manages game state and handles
 
 [![Database Schema Diagram](schema.png)](https://dbdiagram.io/d/5d28ffa3ced98361d6dc9ccb)
 
-### API Endpoints
+## API Endpoints
 
-- [Create/Initiate Game](#create_game)
-- [Join Existing Game](#join_game)
+- [Create/Initiate Game](#create-game)
+- [Join Existing Game](#join-game)
 
-#### Create Game
+---
+
+### Create Game
 
 Request that the server create a new Game instance and attach the requesting user as a Player. Because we are not managing persistent users at this time, this endpoint also creates a User record for the requesting user.
 
@@ -76,7 +78,9 @@ HTTP/1.1 401 Unauthorized
 
 </details>
 
-#### Join Game
+---
+
+### Join Game
 
 Request that the server create a new Player instance for the requesting user and attach it to the Game denoted by the invite code.
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,58 @@ This is the server side of the Codewords game. It manages game state and handles
 ### Schema
 
 [![Database Schema Diagram](schema.png)](https://dbdiagram.io/d/5d28ffa3ced98361d6dc9ccb)
+
+### API Endpoints
+
+- [Create/Initiate Game](#create_game)
+
+#### Create Game
+
+Request that the server create a new Game instance and attach the requesting user as a Player. Because we are not managing persistent users at this time, this endpoint also creates a User record for the requesting user.
+
+##### Request
+```http
+POST /api/v1/games
+```
+```js
+{
+  "name": "Archer"
+}
+```
+|key|description|
+|:---:|:--- |
+|`name`|The username that the requesting user would like to use during the game|
+
+##### Successful Response
+```http
+HTTP/1.1 201 Created
+```
+```js
+{
+  "game_channel": "game_9aZReVkGAotVahGLS88vEnYw",
+  "invite_code": "L6J5suAqTsKUAjEXm5swoEUN",
+  "name": "Archer",
+  "token": "uuxHQc7djqQuzWgJxAp5r1vy"
+}
+```
+|key|description|
+|:---:|:--- |
+|`game_channel`|The Websockets channel that players will connect to for game-wide data updates.|
+|`invite_code`|A code which can be shared with other players. They will use this code to join the game.|
+|`name`|A confirmation that the requested name was indeed assigned to the player.|
+|`token`|A token unique to the current player, which can be used to identify them in future requests to the server.|
+
+<details><summary>Failed Responses</summary>
+
+##### Name Omitted
+This error occurs if the body of the request does not contain a `name`, or if the `name` is empty. 
+```http
+HTTP/1.1 401 Unauthorized
+```
+```js
+{
+  "error": "You must provide a username"
+}
+```
+
+</details>

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -11,9 +11,8 @@ class Api::V1::GamesController < Api::V1::ApiController
         token: player.token
       }
     elsif
-      render status: 401, json: {
-        error: "You must provide a username"
-      }
+      render_error message: "You must provide a username"
+    end
   end
 
   def join

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -14,6 +14,19 @@ class Api::V1::GamesController < Api::V1::ApiController
       render status: 401, json: {
         error: "You must provide a username"
       }
+  end
+
+  def join
+    if params[:name]
+    else
+      render_error message: "You must provide a username"
     end
   end
+
+  private
+    def render_error status: 401, message: "Unauthorized"
+      render status: status, json: {
+        error: message
+      }
+    end
 end

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -18,6 +18,22 @@ class Api::V1::GamesController < Api::V1::ApiController
 
   def join
     if params[:name]
+      game = Game.includes(:users).find_by(invite_code: params[:invite_code])
+      if game.nil?
+        render_error message: "That invite code is invalid"
+      elsif game.full?
+        render_error message: "That game is already full"
+      elsif game.username_taken? params[:name]
+        render_error message: "That username is already taken"
+      else
+        user = User.create(name: params[:name])
+        player = game.players.create(user: user)
+        render status: 200, json: {
+          game_channel: "game_#{game.game_key}",
+          name: user.name,
+          token: player.token
+        }
+      end
     else
       render_error message: "You must provide a username"
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -11,4 +11,14 @@ class Game < ApplicationRecord
   has_secure_token :game_key
   has_secure_token :intel_key
   has_secure_token :invite_code
+
+  def username_taken? name
+    users.any? do |user|
+      user.name == name
+    end
+  end
+
+  def full?
+    users.size > 3
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   scope module: 'api/v1', path: 'api/v1' do
     post '/games', to: 'games#create', as: :create_game
+    post '/games/:invite_code/players', to: 'games#join', as: :join_game
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -15,4 +15,44 @@ RSpec.describe Game, type: :model do
     it { should have_many(:hints) }
     it { should have_many(:guesses) }
   end
+
+  describe "Instance Methods" do
+    let(:game){ Game.create() }
+    let(:player1){ User.create(name: "Archer")}
+    let(:player2){ User.create(name: "Lana")}
+    let(:player3){ User.create(name: "Cyril")}
+    let(:player4){ User.create(name: "Cheryl")}
+
+    describe '.username_taken?' do
+      it 'returns false if the username is not yet taken' do
+        game.users += [player1, player2, player3]
+        result = game.username_taken? player4.name
+
+        expect(result).to eq(false)
+      end
+
+      it 'returns true if another player on the game has the given username' do
+        game.users += [player1, player2, player3]
+        result = game.username_taken? player2.name
+
+        expect(result).to eq(true)
+      end
+    end
+
+    describe '.full?' do
+      it 'returns false if the game is not yet full' do
+        game.users += [player1, player2, player3]
+        result = game.full?
+
+        expect(result).to eq(false)
+      end
+
+      it 'returns true if the game is full' do
+        game.users += [player1, player2, player3, player4]
+        result = game.full?
+
+        expect(result).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/requests/game_request_spec.rb
+++ b/spec/requests/game_request_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Games", type: :request do
 
     it "prevents overfilling a game" do
       post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
-      invite_code = "some-nonsense"
+      invite_code = JSON.parse(response.body, symbolize_names: true)[:invite_code]
       post join_game_path(invite_code), params: {name: "Lana"}, headers: {'Accept' => 'application/json'}
       post join_game_path(invite_code), params: {name: "Cyril"}, headers: {'Accept' => 'application/json'}
       post join_game_path(invite_code), params: {name: "Cheryl"}, headers: {'Accept' => 'application/json'}

--- a/spec/requests/game_request_spec.rb
+++ b/spec/requests/game_request_spec.rb
@@ -21,4 +21,66 @@ RSpec.describe "Games", type: :request do
       expect(data[:error]).to eq("You must provide a username")
     end
   end
+
+  describe "POST /games/:invite_code/players" do
+    it "adds the new player" do
+      post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
+      invite_code = JSON.parse(response.body, symbolize_names: true)[:invite_code]
+
+      post join_game_path(invite_code), params: {name: "Lana"}, headers: {'Accept' => 'application/json'}
+      expect(response).to have_http_status(:ok)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data[:name]).to eq("Lana")
+      expect(data).to have_key(:game_channel)
+      expect(data).to have_key(:token)
+    end
+
+    it "requires a username" do
+      post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
+      invite_code = JSON.parse(response.body, symbolize_names: true)[:invite_code]
+
+      post join_game_path(invite_code)
+      expect(response).to have_http_status(:unauthorized)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data[:error]).to eq("You must provide a username")
+    end
+
+    it "blocks duplicate usernames" do
+      post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
+      invite_code = JSON.parse(response.body, symbolize_names: true)[:invite_code]
+
+      post join_game_path(invite_code), params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
+      expect(response).to have_http_status(:unauthorized)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data[:error]).to eq("That username is already taken")
+    end
+
+    it "requires a valid invite code" do
+      post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
+      invite_code = "some-nonsense"
+
+      post join_game_path(invite_code), params: {name: "Lana"}, headers: {'Accept' => 'application/json'}
+      expect(response).to have_http_status(:unauthorized)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data[:error]).to eq("That invite code is invalid")
+    end
+
+    it "prevents overfilling a game" do
+      post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
+      invite_code = "some-nonsense"
+      post join_game_path(invite_code), params: {name: "Lana"}, headers: {'Accept' => 'application/json'}
+      post join_game_path(invite_code), params: {name: "Cyril"}, headers: {'Accept' => 'application/json'}
+      post join_game_path(invite_code), params: {name: "Cheryl"}, headers: {'Accept' => 'application/json'}
+
+      post join_game_path(invite_code), params: {name: "Brett"}, headers: {'Accept' => 'application/json'}
+      expect(response).to have_http_status(:unauthorized)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data[:error]).to eq("That game is already full")
+    end
+  end
 end


### PR DESCRIPTION
# Description
Closes #4 

```
As a user
  when I send a POST request to /api/v1/games/:invite_code/players
  where :invite_code is a code provided by a friend who has created a game
  and I include a JSON body with the username I wish to use during the game
I receive a JSON response including
  a channel name I can subscribe to for game events
  my approved username
  an access token I can use to communicate with the server about this game
```

Once a game has been created, additional players will be provided with an `invite_code` by the player who created the game. They will then send a POST request as defined in the user story above, with the provided invite code inserted where the placeholder is shown in the path. The server will then find the matching Game, create a User in its database, and attach the user to the game as a Player.

As when creating the game, the server will generate a unique token for the new player, and will respond with the Websockets channel name for the game, the player's confirmed name, and their unique token.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:


## Has This Been Tested?

- [ ] No
- [x] Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
Added tests covering all paths defined in the referenced Issue.
Added tests for instance methods added to Game model
- [ ] Have any prior tests been changed?
If so, please explain:


# Additional notes:
N/A


# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
