### PR TITLE
Websockets: Broadcast when player joins

### DIFF
--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -5,6 +5,7 @@ class GameDataChannel < ApplicationCable::Channel
     # ActionCable doesn't give access to params[] here if mounted in application.rb
     @player = Player.includes(:game, :user).find_by(token: connection.current_player.token)
     stream_from "game_#{@player.game.game_key}"
+    ensure_confirmation_sent
   end
 
   def unsubscribed

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -26,8 +26,9 @@ class GameDataChannel < ApplicationCable::Channel
       broadcast_message = {
         type: "player-joined",
         data: {
-          message: "#{@player.name} has joined!",
-          roster: compose_players(@player.game)
+          id: @player.id,
+          name: @player.name,
+          playerRoster: compose_players(@player.game)
         }
       }
       ActionCable.server.broadcast "game_#{@player.game.game_key}", message: broadcast_message.to_json

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -1,10 +1,34 @@
 class GameDataChannel < ApplicationCable::Channel
+  on_subscribe :welcome_player
+
   def subscribed
-    player = Player.includes(:game, :user).find_by(token: connection.current_player.token)
-    stream_from "game_#{player.game.game_key}"
+    # ActionCable doesn't give access to params[] here if mounted in application.rb
+    @player = Player.includes(:game, :user).find_by(token: connection.current_player.token)
+    stream_from "game_#{@player.game.game_key}"
   end
 
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
+
+  private
+    def compose_players(game)
+      game.players.map do |player|
+        {
+          id: player.id,
+          name: player.name
+        }
+      end
+    end
+
+    def welcome_player
+      broadcast_message = {
+        type: "player-joined",
+        data: {
+          message: "#{@player.name} has joined!",
+          roster: compose_players(@player.game)
+        }
+      }
+      ActionCable.server.broadcast "game_#{@player.game.game_key}", message: broadcast_message.to_json
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,4 @@ Rails.application.routes.draw do
     post '/games', to: 'games#create', as: :create_game
     post '/games/:invite_code/players', to: 'games#join', as: :join_game
   end
-
-  # mount ActionCable.server => '/cable/:token'
 end

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -24,6 +24,11 @@ describe GameDataChannel, type: :channel do
         payload = message[:data]
         expect(payload[:id]).to eq(@player.id)
         expect(payload[:name]).to eq(@player.name)
+
+        players = payload[:playerRoster]
+        expect(players).to be_instance_of(Array)
+        expect(players[0]).to have_key(:id)
+        expect(players[0]).to have_key(:name)
       }
   end
 end


### PR DESCRIPTION
# Description
 Closes #13 
```
When a player joins the game
The server will broadcast the roster of players currently in the game
  including the player that just joined
    with their id and name
  including a collection of all players who have joined
    with their id and name
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No (there is no component for our testing framework that would handle this particular situation)
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Tests that broadcast is sent as part of the subscription process.
      Tests broadcast payload to ensure it conforms to expected structure.
- [ ] Have any prior tests been changed?
      If so, please explain:

# Additional notes:

Testing this was "interesting".

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
