### PR TITLE
Websockets: Broadcast game setup when all players are in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,10 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
 end
 
+group :test do
+  gem 'database_cleaner'
+end
+
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.8.0)
@@ -252,6 +253,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara
+  database_cleaner
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -58,7 +58,7 @@ class GameDataChannel < ApplicationCable::Channel
 
     def start_game
       game = @player.game
-      game.players.load
+      game.reload
       if all_players_in?(game)
         game.establish!
 

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -59,7 +59,7 @@ class GameDataChannel < ApplicationCable::Channel
     def start_game
       game = @player.game
       game.players.load
-      if all_players_in?
+      if all_players_in?(game)
         game.establish!
 
         broadcast_message = {
@@ -71,6 +71,7 @@ class GameDataChannel < ApplicationCable::Channel
           }
         }
         ActionCable.server.broadcast "game_#{@player.game.game_key}", message: broadcast_message.to_json
+      end
     end
 
     def all_players_in?(game)

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -1,5 +1,5 @@
 class GameDataChannel < ApplicationCable::Channel
-  on_subscribe :welcome_player, :start_game
+  on_subscribe :welcome_player
 
   def subscribed
     # ActionCable doesn't give access to params[] here if mounted in application.rb
@@ -54,6 +54,7 @@ class GameDataChannel < ApplicationCable::Channel
         }
       }
       ActionCable.server.broadcast "game_#{@player.game.game_key}", message: broadcast_message.to_json
+      start_game
     end
 
     def start_game

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -13,6 +13,15 @@ class GameDataChannel < ApplicationCable::Channel
   end
 
   private
+    def compose_roster(game)
+      game.players.map do |p|
+        {
+          id: p.id,
+          name: p.name
+        }
+      end
+    end
+
     def compose_players(game)
       game.players.map do |player|
         {
@@ -28,7 +37,7 @@ class GameDataChannel < ApplicationCable::Channel
         data: {
           id: @player.id,
           name: @player.name,
-          playerRoster: compose_players(@player.game)
+          playerRoster: compose_roster(@player.game)
         }
       }
       ActionCable.server.broadcast "game_#{@player.game.game_key}", message: broadcast_message.to_json

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -4,6 +4,7 @@ class GameDataChannel < ApplicationCable::Channel
   def subscribed
     # ActionCable doesn't give access to params[] here if mounted in application.rb
     @player = Player.includes(:game, :user).find_by(token: connection.current_player.token)
+    @player.update(subscribed: true)
     stream_from "game_#{@player.game.game_key}"
     ensure_confirmation_sent
   end

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -72,4 +72,8 @@ class GameDataChannel < ApplicationCable::Channel
         }
         ActionCable.server.broadcast "game_#{@player.game.game_key}", message: broadcast_message.to_json
     end
+
+    def all_players_in?(game)
+      game.player_count == game.players.count{|p| p.subscribed?}
+    end
 end

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -23,10 +23,22 @@ class GameDataChannel < ApplicationCable::Channel
     end
 
     def compose_players(game)
-      game.players.map do |player|
+      game.players.map do |p|
         {
-          id: player.id,
-          name: player.name
+          id: p.id,
+          name: p.name,
+          isBlueTeam: p.blue?,
+          isIntel: p.intel?
+        }
+      end
+    end
+
+    def compose_cards(game)
+      cards = game.game_cards.sort_by &:address
+      cards.map do |c|
+        {
+          id: c.id,
+          word: c.word
         }
       end
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -31,13 +31,13 @@ class Game < ApplicationRecord
     users.size > 3
   end
 
+  def blue_first?
+    coin_flip > 0
+  end
+
   private
     def coin_flip
       @_coin_flip ||= Random.rand(0..1)
-    end
-
-    def blue_first?
-      coin_flip > 0
     end
 
     def blue_cards

--- a/db/migrate/20190720171829_add_player_count_to_game.rb
+++ b/db/migrate/20190720171829_add_player_count_to_game.rb
@@ -1,0 +1,5 @@
+class AddPlayerCountToGame < ActiveRecord::Migration[5.2]
+  def change
+    add_column :games, :player_count, :integer, default: 4
+  end
+end

--- a/db/migrate/20190720171903_add_subscribed_to_player.rb
+++ b/db/migrate/20190720171903_add_subscribed_to_player.rb
@@ -1,0 +1,5 @@
+class AddSubscribedToPlayer < ActiveRecord::Migration[5.2]
+  def change
+    add_column :players, :subscribed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_20_000700) do
+ActiveRecord::Schema.define(version: 2019_07_20_171903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_07_20_000700) do
     t.string "invite_code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "player_count", default: 4
     t.index ["game_key"], name: "index_games_on_game_key", unique: true
     t.index ["intel_key"], name: "index_games_on_intel_key", unique: true
     t.index ["invite_code"], name: "index_games_on_invite_code", unique: true
@@ -72,6 +73,7 @@ ActiveRecord::Schema.define(version: 2019_07_20_000700) do
     t.string "token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "subscribed", default: false
     t.index ["game_id"], name: "index_players_on_game_id"
     t.index ["token"], name: "index_players_on_token", unique: true
     t.index ["user_id"], name: "index_players_on_user_id"

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -4,10 +4,6 @@ describe GameDataChannel, type: :channel do
   let(:user){User.create(name: "Archer")}
   let(:game){Game.create}
 
-  before(:all) do
-    require './db/seeds/cards'
-  end
-
   before(:each) do
     @player = game.players.create(user: user)
     stub_connection current_player: @player

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe GameDataChannel, type: :channel do
   let(:user){User.create(name: "Archer")}
-  let(:game){Game.create()}
+  let(:game){Game.create}
 
   before do
     @player = game.players.create(user: user)
@@ -29,6 +29,48 @@ describe GameDataChannel, type: :channel do
         expect(players).to be_instance_of(Array)
         expect(players[0]).to have_key(:id)
         expect(players[0]).to have_key(:name)
+      }
+  end
+
+  it 'broadcasts game start info once all players are in' do
+    subscribe
+
+    user2 = game.users << User.create(name: "Lana")
+    stub_connection current_player: user2.players.first
+    subscribe
+
+    user3 = game.users << User.create(name: "Cyril")
+    stub_connection current_player: user3.players.first
+    subscribe
+
+    user4 = game.users << User.create(name: "Cheryl")
+    stub_connection current_player: user4.players.first
+
+    expect{ subscribe }.to have_broadcasted_to("game_#{game.game_key}")
+      .with{ |data|
+        message = JSON.parse(data[:message], symbolize_names: true)
+        unless message[:type] == "player-joined"
+          expect(message[:type]).to eq("game-start")
+
+          payload = message[:data]
+          expect(payload).to have_key(:cards)
+
+          payload[:cards].each do |card|
+            expect(card).to have_key(:id)
+            expect(card).to have_key(:word)
+          end
+
+          expect(payload).to have_key(:players)
+
+          payload[:players].each do |player|
+            expect(player).to have_key(:id)
+            expect(player).to have_key(:name)
+            expect(player).to have_key(:isBlueTeam)
+            expect(player).to have_key(:isIntel)
+          end
+
+          expect(payload).to have_key(:firstTeam)
+        end
       }
   end
 end

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -4,7 +4,11 @@ describe GameDataChannel, type: :channel do
   let(:user){User.create(name: "Archer")}
   let(:game){Game.create}
 
-  before do
+  before(:all) do
+    require './db/seeds/cards'
+  end
+
+  before(:each) do
     @player = game.players.create(user: user)
     stub_connection current_player: @player
   end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe Game, type: :model do
     let(:player3){ User.create(name: "Cyril")}
     let(:player4){ User.create(name: "Cheryl")}
 
-    before(:all) do
-      require './db/seeds/cards'
-    end
-
     describe '.username_taken?' do
       it 'returns false if the username is not yet taken' do
         game.users += [player1, player2, player3]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,3 +96,11 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+require 'database_cleaner'
+DatabaseCleaner.strategy = :truncation
+require './db/seeds/cards'
+
+RSpec.configure do |config|
+  config.after(:suite){ DatabaseCleaner.clean }
+end

--- a/spec/requests/intel_request_spec.rb
+++ b/spec/requests/intel_request_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "Intel", type: :request do
   describe "GET /api/v1/intel" do
     describe "success" do
       it "returns the card metadata for the game" do
-        require './db/seeds/cards'
         game = Game.create
         game.users << User.create(name: "Archer")
         game.users << User.create(name: "Lana")

--- a/spec/requests/intel_request_spec.rb
+++ b/spec/requests/intel_request_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "Intel", type: :request do
         game.users << User.create(name: "Cheryl")
         players = game.players
 
-        oldLogger = ActiveRecord::Base.logger
         game.establish!
 
         players[0].role = :intel


### PR DESCRIPTION
# Description

Closes #14 
```
When all players have joined
The server will broadcast initial game state
  including each player
    with their id, name, team, and role
  including each card
    with its id and word
  including a flag indicating the first team to play
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Tests ensure that broadcast payload conforms to spec as listed in #14 
      Tests ensure game-setup broadcast happens when the last player subscribes
      Tests ensure game-setup broadcast _only_ happens when the last player subscribes
- [ ] Have any prior tests been changed?
      If so, please explain:

# Additional notes:

Additional migrations have been added. After pulling, please run `rails db:migrate`

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas