### PR TITLE
Add player id to api endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ POST /api/v1/games
 ```
 |key|description|
 |:---:|:--- |
-|`name`|The username that the requesting user would like to use during the game|
+|`name`|String: The username that the requesting user would like to use during the game|
 
 ##### Successful Response
 ```http
@@ -90,18 +90,18 @@ HTTP/1.1 201 Created
 ```
 ```js
 {
-  "game_channel": "game_9aZReVkGAotVahGLS88vEnYw",
   "invite_code": "L6J5suAqTsKUAjEXm5swoEUN",
+  "id": 0,
   "name": "Archer",
   "token": "uuxHQc7djqQuzWgJxAp5r1vy"
 }
 ```
 |key|description|
 |:---:|:--- |
-|`game_channel`|The Websockets channel that players will connect to for game-wide data updates.|
-|`invite_code`|A code which can be shared with other players. They will use this code to join the game.|
-|`name`|A confirmation that the requested name was indeed assigned to the player.|
-|`token`|A token unique to the current player, which can be used to identify them in future requests to the server.|
+|`invite_code`|String: A code which can be shared with other players. They will use this code to join the game.|
+|`id`|Integer: The unique id for the player.|
+|`name`|String: A confirmation that the requested name was indeed assigned to the player.|
+|`token`|String: A token unique to the current player, which can be used to identify them in future requests to the server.|
 
 <details><summary>Failed Responses</summary>
 
@@ -135,8 +135,8 @@ POST /api/v1/games/:invite_code/players
 ```
 |key|description|
 |:---:|:--- |
-|`:invite_code`| (Within URI) The invite code provided by the person inviting the requesting user to their existing game.|
-|`name`|The username that the requesting user would like to use during the game|
+|`:invite_code`|String: (Within URI) The invite code provided by the person inviting the requesting user to their existing game.|
+|`name`|String: The username that the requesting user would like to use during the game|
 
 ##### Successful Response
 ```http
@@ -144,16 +144,16 @@ HTTP/1.1 200 OK
 ```
 ```js
 {
-  "game_channel": "game_9aZReVkGAotVahGLS88vEnYw",
+  "id": 0,
   "name": "Lana",
   "token": "uuxHQc7djqQuzWgJxAp5r1vy"
 }
 ```
 |key|description|
 |:---:|:--- |
-|`game_channel`|The Websockets channel that players will connect to for game-wide data updates.|
-|`name`|A confirmation that the requested name was indeed assigned to the player.|
-|`token`|A token unique to the current player, which can be used to identify them in future requests to the server.|
+|`id`|Integer: The unique id for the player.|
+|`name`|String: A confirmation that the requested name was indeed assigned to the player.|
+|`token`|String: A token unique to the current player, which can be used to identify them in future requests to the server.|
 
 <details><summary>Failed Responses</summary>
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ GET /api/v1/intel
 ```
 |key|description|
 |:---:|:--- |
-|`token`| A valid token belonging to a Player with the Intel role.|
+|`token`|String: A valid token belonging to a Player with the Intel role.|
 
 ##### Successful Response
 ```http
@@ -230,17 +230,17 @@ HTTP/1.1 200 OK
 {
   "cards": [
     {
-      "id": 0, // int card id
-      "type": "red" // red, blue, bystander, or assassin
-    }, // ... one for each card
+      "id": 0,
+      "type": "red"
+    }, ...
   ]
 }
 ```
 |key|description|
 |:---:|:--- |
-|`cards`|A collection of cards which are part of the game.|
-|`id`|The unique identifier for the card.|
-|`type`|The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
+|`cards`|Array: A collection of `card` objects which are part of the game.|
+|`-->card.id`|Integer: The unique identifier for the card.|
+|`-->card.type`|String:The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
 
 <details><summary>Failed Responses</summary>
 
@@ -291,11 +291,11 @@ This message is broadcast to the game channel whenever a player joins the game. 
 {
   type: "player-joined",
   data: {
-    id: id,
+    id: 0,
     name: "name",
     playerRoster: [
       {
-        id: id,
+        id: 0,
         name: "name"
       },
       ...
@@ -308,13 +308,13 @@ This message is broadcast to the game channel whenever a player joins the game. 
 
 |key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
 |:---               |:--- |
-|`type`             |The type of message being broadcast.|
-|`data`             |The data payload of the message.|
-|`data.id`          |The unique id of the player who joined.|
-|`data.name`        |The name of the player who joined.|
-|`data.playerRoster`|A collection of all players currently in the game. Each is an object with an id and name.|
-|`-->player.id`     |The unique id of the given player.|
-|`-->player.name`   |The name of the given player.|
+|`type`             |String: The type of message being broadcast.|
+|`data`             |Object: The data payload of the message.|
+|`data.id`          |Integer: The unique id of the player who joined.|
+|`data.name`        |String: The name of the player who joined.|
+|`data.playerRoster`|Array: A collection of `player` objects for all players currently in the game.|
+|`-->player.id`     |Integer: The unique id of the given player.|
+|`-->player.name`   |String: The name of the given player.|
 
 </div>
 
@@ -328,25 +328,25 @@ This message is broadcast to the game channel once the final player has joined t
 
 ```js
 {
-  type: 'game-setup',
+  type: "game-setup",
   data: {
     cards: [
       {
-        id: id,
-        word: 'someword'
+        id: 0,
+        word: "someword"
       },
       ...
     ],
     players: [
       {
-        id: id,
+        id: 0,
         name: "name",
-        isBlueTeam: true, // boolean
-        isIntel: true // boolean
+        isBlueTeam: true,
+        isIntel: true
       },
       ...
     ],
-    firstTeam: "red" // red/blue
+    firstTeam: "red"
   }
 }
 ```
@@ -354,16 +354,16 @@ This message is broadcast to the game channel once the final player has joined t
 
 |key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|description|
 |:---                  |:--- |
-|`type`                |The type of message being broadcast.|
-|`data`                |The data payload of the message.|
-|`data.cards`          |An ordered collection of cards that will be used in the game. The order of these cards goes onto the board left-to-right, top-to-bottom.|
-|`-->card.id`          |The unique id for the given card.|
-|`-->card.word`        |The word to display on a given card.|
-|`data.players`        |A collection of players in the game.|
-|`-->player.id`        |The unique id for the given player.|
-|`-->player.name`      |The name for the given player.|
+|`type`                |String: The type of message being broadcast.|
+|`data`                |Object: The data payload of the message.|
+|`data.cards`          |Array: An **ordered** collection of `card` objects that will be used in the game. The order of these cards goes onto the board left-to-right, top-to-bottom.|
+|`-->card.id`          |Integer: The unique id for the given card.|
+|`-->card.word`        |String: The word to display on a given card.|
+|`data.players`        |Array: A collection of `player` objects for all players in the game.|
+|`-->player.id`        |Integer: The unique id for the given player.|
+|`-->player.name`      |String: The name for the given player.|
 |`-->player.isBlueTeam`|Boolean: `true` if the player is on the blue team, `false` if they're on the red team.|
 |`-->player.isIntel`   |Boolean: `true` if the player has the Intel role, `false` if they don't.|
-|`data.firstTeam`      |The team that will play first: "red" or "blue".|
+|`data.firstTeam`      |String: The team that will play first: "red" or "blue".|
 
 </div>

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::GamesController < Api::V1::ApiController
       game = Game.create()
       player = game.players.create(user: user)
       render status: 201, json: {
-        game_channel: "game_#{game.game_key}",
         invite_code: game.invite_code,
         id: player.id,
         name: player.name,
@@ -29,7 +28,6 @@ class Api::V1::GamesController < Api::V1::ApiController
         user = User.create(name: params[:name])
         player = game.players.create(user: user)
         render status: 200, json: {
-          game_channel: "game_#{game.game_key}",
           id: player.id,
           name: player.name,
           token: player.token

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::GamesController < Api::V1::ApiController
       render status: 201, json: {
         game_channel: "game_#{game.game_key}",
         invite_code: game.invite_code,
-        name: user.name,
+        id: player.id,
+        name: player.name,
         token: player.token
       }
     elsif
@@ -29,7 +30,8 @@ class Api::V1::GamesController < Api::V1::ApiController
         player = game.players.create(user: user)
         render status: 200, json: {
           game_channel: "game_#{game.game_key}",
-          name: user.name,
+          id: player.id,
+          name: player.name,
           token: player.token
         }
       end

--- a/spec/requests/game_request_spec.rb
+++ b/spec/requests/game_request_spec.rb
@@ -6,11 +6,14 @@ RSpec.describe "Games", type: :request do
       post create_game_path, params: {name: "Archer"}, headers: {'Accept' => 'application/json'}
       expect(response).to have_http_status(:created)
 
+      player = Player.last
+      expect(player.name).to eq("Archer")
+
       data = JSON.parse(response.body, symbolize_names: true)
-      expect(data[:name]).to eq("Archer")
-      expect(data).to have_key(:game_channel)
-      expect(data).to have_key(:invite_code)
-      expect(data).to have_key(:token)
+      expect(data[:id]).to eq(player.id)
+      expect(data[:name]).to eq(player.name)
+      expect(data[:invite_code]).to eq(player.game.invite_code)
+      expect(data[:token]).to eq(player.token)
     end
 
     it "requires a username" do
@@ -30,10 +33,13 @@ RSpec.describe "Games", type: :request do
       post join_game_path(invite_code), params: {name: "Lana"}, headers: {'Accept' => 'application/json'}
       expect(response).to have_http_status(:ok)
 
+      player = Player.last
+      expect(player.name).to eq("Lana")
+
       data = JSON.parse(response.body, symbolize_names: true)
-      expect(data[:name]).to eq("Lana")
-      expect(data).to have_key(:game_channel)
-      expect(data).to have_key(:token)
+      expect(data[:id]).to eq(player.id)
+      expect(data[:name]).to eq(player.name)
+      expect(data[:token]).to eq(player.token)
     end
 
     it "requires a username" do


### PR DESCRIPTION
# Description

Closes #23 

Endpoints for creating a game and joining a game now also return the `id` of the player, and no longer return the `game_channel` key that is not used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Adjusted test expectations to fit new format: Adds expectation for player id, removes expectation for game_channel
- [x] Have any prior tests been changed?
      If so, please explain:
      See above

# Additional notes:

Also updated documentation for other endpoints so that the formatting is consistent across all.

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas