### PR TITLE
Bugfix: Reuse usernames across different games

### DIFF
--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::GamesController < Api::V1::ApiController
   def create
     if params[:name]
-      user = User.create(name: params[:name])
-      game = Game.create()
+      user = User.find_or_create_by(name: params[:name])
+      game = Game.create
       player = game.players.create(user: user)
       render status: 201, json: {
         invite_code: game.invite_code,
@@ -25,7 +25,7 @@ class Api::V1::GamesController < Api::V1::ApiController
       elsif game.username_taken? params[:name]
         render_error message: "That username is already taken"
       else
-        user = User.create(name: params[:name])
+        user = User.find_or_create_by(name: params[:name])
         player = game.players.create(user: user)
         render status: 200, json: {
           id: player.id,


### PR DESCRIPTION
# Description

Fixes #25 

Users were being prevented from joining a game if they provided a name which had ever been used in the past. This changes the user creation step to reuse existing User records, since we're not doing any registration at this time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Added tests to cover situations where a user with a given name already exists in the DB and another user tries to create or join a different game with the same name.
      Situations where a user tries to use the same name as an existing user within the _same_ game were already covered by prior tests.
- [ ] Have any prior tests been changed?
      If so, please explain:

# Additional notes:

Oops.

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas