### PR TITLE
API: Add card words to Get Intel endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,15 +211,10 @@ Request the Intel data for a game, allowing the player to see which cards belong
 
 ##### Request
 ```http
-GET /api/v1/intel
+GET /api/v1/intel?token=<player_token>
 ```
-```js
-{
-  "token": "uuxHQc7djqQuzWgJxAp5r1vy"
-}
-```
-|key|description|
-|:---:|:--- |
+|key    |description|
+|:---:  |:--- |
 |`token`|String: A valid token belonging to a Player with the Intel role.|
 
 ##### Successful Response
@@ -231,21 +226,23 @@ HTTP/1.1 200 OK
   "cards": [
     {
       "id": 0,
+      "word": "<card word>",
       "type": "red"
     }, ...
   ]
 }
 ```
-|key|description|
-|:---:|:--- |
-|`cards`|Array: A collection of `card` objects which are part of the game.|
-|`-->card.id`|Integer: The unique identifier for the card.|
-|`-->card.type`|String:The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
+|key           |description|
+|:---:         |:--- |
+|`cards`       |Array: An **ordered** collection of `card` objects which are part of the game. These cards go onto the board left-to-right, top-to-bottom.|
+|`-->card.id`  |Integer: The unique identifier for the card.|
+|`-->card.word`|String: The word for the card.|
+|`-->card.type`|String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
 
 <details><summary>Failed Responses</summary>
 
 ##### Token Omitted
-This error occurs if the body of the request does not contain a `token`, or if the `token` is empty.
+This error occurs if the querystring of the request does not contain a `token`, or if the `token` is empty.
 ```http
 HTTP/1.1 401 Unauthorized
 ```

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ At this point, we have everything we need for our Rails environment. If you wish
 
 ## Websockets Message Events
 
-|From Server|From Client|
-|:---:|:---:|
-|[Player Joined](#player-joined)|
-|[Game Started](#game-started)|
+|From Server                    |From Client|
+|:---:                          |:---:|
+|[Player Joined](#player-joined)|     |
+|[Game Started](#game-started)  |     |
 
 ---
 
@@ -80,8 +80,8 @@ POST /api/v1/games
   "name": "Archer"
 }
 ```
-|key|description|
-|:---:|:--- |
+|key   |description|
+|:---: |:--- |
 |`name`|String: The username that the requesting user would like to use during the game|
 
 ##### Successful Response
@@ -96,12 +96,12 @@ HTTP/1.1 201 Created
   "token": "uuxHQc7djqQuzWgJxAp5r1vy"
 }
 ```
-|key|description|
-|:---:|:--- |
+|key          |description|
+|:---:        |:--- |
 |`invite_code`|String: A code which can be shared with other players. They will use this code to join the game.|
-|`id`|Integer: The unique id for the player.|
-|`name`|String: A confirmation that the requested name was indeed assigned to the player.|
-|`token`|String: A token unique to the current player, which can be used to identify them in future requests to the server.|
+|`id`         |Integer: The unique id for the player.|
+|`name`       |String: A confirmation that the requested name was indeed assigned to the player.|
+|`token`      |String: A token unique to the current player, which can be used to identify them in future requests to the server.|
 
 <details><summary>Failed Responses</summary>
 
@@ -133,10 +133,10 @@ POST /api/v1/games/:invite_code/players
   "name": "Lana"
 }
 ```
-|key|description|
-|:---:|:--- |
+|key           |description|
+|:---:         |:--- |
 |`:invite_code`|String: (Within URI) The invite code provided by the person inviting the requesting user to their existing game.|
-|`name`|String: The username that the requesting user would like to use during the game|
+|`name`        |String: The username that the requesting user would like to use during the game|
 
 ##### Successful Response
 ```http
@@ -149,10 +149,10 @@ HTTP/1.1 200 OK
   "token": "uuxHQc7djqQuzWgJxAp5r1vy"
 }
 ```
-|key|description|
-|:---:|:--- |
-|`id`|Integer: The unique id for the player.|
-|`name`|String: A confirmation that the requested name was indeed assigned to the player.|
+|key    |description|
+|:---:  |:--- |
+|`id`   |Integer: The unique id for the player.|
+|`name` |String: A confirmation that the requested name was indeed assigned to the player.|
 |`token`|String: A token unique to the current player, which can be used to identify them in future requests to the server.|
 
 <details><summary>Failed Responses</summary>
@@ -309,7 +309,7 @@ This message is broadcast to the game channel whenever a player joins the game. 
 |`data`             |Object: The data payload of the message.|
 |`data.id`          |Integer: The unique id of the player who joined.|
 |`data.name`        |String: The name of the player who joined.|
-|`data.playerRoster`|Array: A collection of `player` objects for all players currently in the game.|
+|`data.playerRoster`|Array: A collection of `player` objects for all players currently in the game, **ordered by** the time they joined the lobby.|
 |`-->player.id`     |Integer: The unique id of the given player.|
 |`-->player.name`   |String: The name of the given player.|
 
@@ -353,10 +353,10 @@ This message is broadcast to the game channel once the final player has joined t
 |:---                  |:--- |
 |`type`                |String: The type of message being broadcast.|
 |`data`                |Object: The data payload of the message.|
-|`data.cards`          |Array: An **ordered** collection of `card` objects that will be used in the game. The order of these cards goes onto the board left-to-right, top-to-bottom.|
+|`data.cards`          |Array: An **ordered** collection of `card` objects that will be used in the game. These cards go onto the board left-to-right, top-to-bottom.|
 |`-->card.id`          |Integer: The unique id for the given card.|
 |`-->card.word`        |String: The word to display on a given card.|
-|`data.players`        |Array: A collection of `player` objects for all players in the game.|
+|`data.players`        |Array: A collection of `player` objects for all players in the game, **ordered by** the time they joined the lobby.|
 |`-->player.id`        |Integer: The unique id for the given player.|
 |`-->player.name`      |String: The name for the given player.|
 |`-->player.isBlueTeam`|Boolean: `true` if the player is on the blue team, `false` if they're on the red team.|

--- a/app/controllers/api/v1/intel_controller.rb
+++ b/app/controllers/api/v1/intel_controller.rb
@@ -27,6 +27,7 @@ class Api::V1::IntelController < Api::V1::ApiController
       game.game_cards.map do |card|
         {
           id: card.id,
+          word: card.word,
           type: card.category
         }
       end

--- a/app/models/game_card.rb
+++ b/app/models/game_card.rb
@@ -10,7 +10,7 @@ class GameCard < ApplicationRecord
   validates :chosen, inclusion: {in: [true, false]}
   validates_numericality_of :address
 
-  default_scope { includes(:card) }
+  default_scope { includes(:card).order(:address) }
 
   def word
     card.word

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -5,6 +5,8 @@ class Player < ApplicationRecord
   enum role: [:spy, :intel]
   enum team: [:red, :blue]
 
+  default_scope { order(:updated_at) }
+
   has_secure_token
 
   def name

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -26,9 +26,16 @@ describe GameDataChannel, type: :channel do
         expect(payload[:name]).to eq(@player.name)
 
         players = payload[:playerRoster]
+        player_ids = []
         expect(players).to be_instance_of(Array)
-        expect(players[0]).to have_key(:id)
-        expect(players[0]).to have_key(:name)
+        players.each do |player|
+          expect(player).to have_key(:id)
+          expect(player).to have_key(:name)
+          player_ids << player[:id]
+        end
+
+        player_resources = Player.find(player_ids).to_a
+        expect(player_resources).to eq(player_resources.sort_by &:updated_at)
       }
   end
 

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -80,6 +80,12 @@ describe GameDataChannel, type: :channel do
             expect(card).to have_key(:word)
           end
 
+          first_card = GameCard.find(payload[:cards].first[:id])
+          expect(first_card.address).to eq(0)
+
+          last_card = GameCard.find(payload[:cards].last[:id])
+          expect(last_card.address).to eq(24)
+
           expect(payload).to have_key(:players)
           expect(payload[:players].count).to eq(4)
 

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -89,12 +89,17 @@ describe GameDataChannel, type: :channel do
           expect(payload).to have_key(:players)
           expect(payload[:players].count).to eq(4)
 
+          player_ids = []
           payload[:players].each do |player|
             expect(player).to have_key(:id)
             expect(player).to have_key(:name)
             expect(player).to have_key(:isBlueTeam)
             expect(player).to have_key(:isIntel)
+            player_ids << player[:id]
           end
+
+          player_resources = Player.find(player_ids).to_a
+          expect(player_resources).to eq(player_resources.sort_by &:updated_at)
 
           expect(payload).to have_key(:firstTeam)
         else

--- a/spec/requests/intel_request_spec.rb
+++ b/spec/requests/intel_request_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Intel", type: :request do
 
         example_card = data[:cards].sample
         expect(example_card).to have_key(:id)
+        expect(example_card).to have_key(:word)
         expect(example_card).to have_key(:type)
       end
     end

--- a/spec/requests/intel_request_spec.rb
+++ b/spec/requests/intel_request_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe "Intel", type: :request do
         expect(example_card).to have_key(:id)
         expect(example_card).to have_key(:word)
         expect(example_card).to have_key(:type)
+
+        first_card = GameCard.find(data[:cards].first[:id])
+        expect(first_card.address).to eq(0)
+
+        last_card = GameCard.find(data[:cards].last[:id])
+        expect(last_card.address).to eq(24)
       end
     end
 


### PR DESCRIPTION
# Description

Closes #27 

Adds the `word` associated with a GameCard to the response from the Get Intel API endpoint so that the payload can be used to populate the game board without needing to merge it with the `game-setup` message contents.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Adjusted test to ensure word is encluded
      Added expectations to ensure cards are ordered consistently across Get Intel endpoint requests and the `game-setup` message (ordered by their `address`, ascending)
      Added expectation to ensure players are likewise consistently ordered across `player-joined` messages and `game-setup` (ordered by the time they joined the game, oldest first)
- [x] Have any prior tests been changed?
      If so, please explain:
      See above

# Additional notes:

Also took the opportunity to spruce up the README source. It won't render differently, but it's more readable in a code editor.

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas