### PR TITLE
Resolve subscriptions not creating correctly

### DIFF
--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -3,7 +3,7 @@ class GameDataChannel < ApplicationCable::Channel
 
   def subscribed
     current_player.update(subscribed: true)
-    stream_from current_player.game
+    stream_for current_player.game
     ensure_confirmation_sent
   end
 
@@ -12,7 +12,6 @@ class GameDataChannel < ApplicationCable::Channel
   end
 
   def send_hint(data)
-    # binding.pry
     game = current_player.game
     if game.current_player != current_player
       illegal_action("#{current_player.name} attempted to submit a hint out of turn")

--- a/spec/channels/game_data_channel_spec.rb
+++ b/spec/channels/game_data_channel_spec.rb
@@ -13,7 +13,7 @@ describe GameDataChannel, type: :channel do
     subscribe
 
     expect(subscription).to be_confirmed
-    expect(subscription).to have_stream_from(game)
+    expect(subscription).to have_stream_for(game)
   end
 
   it 'broadcasts joining player info' do


### PR DESCRIPTION
# Description

One line of the code intended for PR #30 from last night was not committed, and it broke websocket subscriptions entirely. This resolves the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Was using the wrong form for a test expectation, fixed.
- [ ] Have any prior tests been changed?
      If so, please explain:

# Additional notes:

`/facepalm`

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas