### PR TITLE
Add README documentation for missing websockets messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ This message is broadcast to all players after a valid [Hint Sent](#hint-sent) a
 
 ### Guess Sent
 
-This message is sent from the game client to the server by the current player. So long as the sender is the current player and has the Spy role, and the provided ID matches a card in the current game, this will generate a [Board Update](#board-update) broadcast to all players. If any of these requirements are not met, the appropriate [Illegal Action](#illegal-action) message will be broadcast instead.
+This message is sent from the game client to the server by the current player. So long as the sender is the current player and has the Spy role, and the provided ID matches a card in the current game, this will generate a [Board Update](#board-update) broadcast to all players, unless the guess causes the game to end, in which case the [Game Over](#game-over) message will be broadcast instead. If any of these requirements are not met, the appropriate [Illegal Action](#illegal-action) message will be broadcast instead.
 
 ##### Call
 
@@ -432,7 +432,7 @@ cable.sendGuess({
 
 ### Board Update
 
-This message is broadcast to all players after a valid [Guess Sent](#guess-sent) action is performed by a player. After receiving this message, play will proceed to the `currentPlayer` provided in the response.
+This message is broadcast to all players after a valid [Guess Sent](#guess-sent) action is performed by a player, unless the guess causes the game to end (in which case, the [Game Over](#game-over) message will be broadcast instead). After receiving this message, play will proceed to the `currentPlayer` provided in the response.
 
 ##### Payload
 
@@ -461,3 +461,35 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
 |`-->card.type`          |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
 |`data.remainingAttempts`|Integer: The number of guesses remaining.|
 |`data.currentPlayer`    |Integer: The ID of the current player.|
+
+---
+
+### Game Over
+
+This message is broadcast to all players after a valid [Guess Sent](#guess-sent) action causes the game to end. After receiving this message, the game UI will render the end state.
+
+##### Payload
+
+```js
+{
+  type: 'game-over',
+  data: {
+    card: {
+      id: 1,
+      flipped: true,
+      type: "red"
+    },
+    winningTeam: "red"
+  }
+}
+```
+
+|key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
+|:---              |:--- |
+|`type`            |String: The type of message being broadcast.|
+|`data`            |Object: The data payload of the message.|
+|`data.card`       |Object: Data about the card that was guessed.|
+|`-->card.id`      |Integer: The ID of the guessed card.|
+|`-->card.flipped` |Boolean: The flipped state of the card (always `true`).|
+|`-->card.type`    |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
+|`data.winningTeam`|String: The team that won the game.|

--- a/README.md
+++ b/README.md
@@ -493,3 +493,41 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
 |`-->card.flipped` |Boolean: The flipped state of the card (always `true`).|
 |`-->card.type`    |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
 |`data.winningTeam`|String: The team that won the game.|
+
+---
+
+### Illegal Action
+
+This message is broadcast to all players after any illegal action is performed by a player in a [Hint Sent](#hint-sent) or [Game Sent](#guess-sent) action.
+
+##### Payload
+
+```js
+{
+  type: 'illegal-action',
+  data: {
+    error: "<descriptive message>",
+    byPlayerId: 1
+  }
+}
+```
+
+|key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
+|:---             |:--- |
+|`type`           |String: The type of message being broadcast.|
+|`data`           |Object: The data payload of the message.|
+|`data.error`     |String: The descriptive error message.|
+|`data.byPlayerId`|Integer: The ID of the player who performed the illegal action.|
+
+<details><summary>The potential illegal actions that are anticipated and caught are:</summary>
+
+- The player performing the action is not the current player
+  - "<player name> attempted to submit a (hint/guess) out of turn"
+- The player performed an action during their turn, but does not have the correct role for that action
+  - "<player name> attempted to submit a (hint/guess), but does't have the (Intel/Spy) role"
+- An Intel player submits a multi-word hint during their turn
+  - "<player name> attempted to submit an invalid hint"
+- A Spy player submits a guess with a card ID not present in this game
+  - "<player name> attempted to submit a guess for a card not in this game"
+
+</details>

--- a/README.md
+++ b/README.md
@@ -408,3 +408,56 @@ This message is broadcast to all players after a valid [Hint Sent](#hint-sent) a
 |`data.isBlueTeam`  |Boolean: Whether the hint belongs to the Blue team or not.|
 |`data.hintWord`    |String: The hint word provided by the player.|
 |`data.relatedCards`|Integer: The number of cards this hint is related to.|
+
+
+---
+
+### Guess Sent
+
+This message is sent from the game client to the server by the current player. So long as the sender is the current player and has the Spy role, and the provided ID matches a card in the current game, this will generate a [Board Update](#board-update) broadcast to all players. If any of these requirements are not met, the appropriate [Illegal Action](#illegal-action) message will be broadcast instead.
+
+##### Call
+
+```js
+cable.sendGuess({
+  id: 1
+})
+```
+
+|key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
+|:--- |:--- |
+|`id` |Integer: The ID of the guessed card.|
+
+---
+
+### Board Update
+
+This message is broadcast to all players after a valid [Guess Sent](#guess-sent) action is performed by a player. After receiving this message, play will proceed to the `currentPlayer` provided in the response.
+
+##### Payload
+
+```js
+{
+  type: 'board-update',
+  data: {
+    card: {
+      id: 1,
+      flipped: true,
+      type: "red"
+    },
+    remainingAttempts: 2,
+    currentPlayer: 1
+  }
+}
+```
+
+|key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
+|:---                    |:--- |
+|`type`                  |String: The type of message being broadcast.|
+|`data`                  |Object: The data payload of the message.|
+|`data.card`             |Object: Data about the card that was guessed.|
+|`-->card.id`            |Integer: The ID of the guessed card.|
+|`-->card.flipped`       |Boolean: The flipped state of the card (always `true`).|
+|`-->card.type`          |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
+|`data.remainingAttempts`|Integer: The number of guesses remaining.|
+|`data.currentPlayer`    |Integer: The ID of the current player.|

--- a/README.md
+++ b/README.md
@@ -522,12 +522,12 @@ This message is broadcast to all players after any illegal action is performed b
 <details><summary>The potential illegal actions that are anticipated and caught are:</summary>
 
 - The player performing the action is not the current player
-  - "<player name> attempted to submit a (hint/guess) out of turn"
+  - "\<player name\> attempted to submit a (hint/guess) out of turn"
 - The player performed an action during their turn, but does not have the correct role for that action
-  - "<player name> attempted to submit a (hint/guess), but does't have the (Intel/Spy) role"
+  - "\<player name\> attempted to submit a (hint/guess), but does't have the (Intel/Spy) role"
 - An Intel player submits a multi-word hint during their turn
-  - "<player name> attempted to submit an invalid hint"
+  - "\<player name\> attempted to submit an invalid hint"
 - A Spy player submits a guess with a card ID not present in this game
-  - "<player name> attempted to submit a guess for a card not in this game"
+  - "\<player name\> attempted to submit a guess for a card not in this game"
 
 </details>

--- a/README.md
+++ b/README.md
@@ -305,8 +305,6 @@ This message is broadcast to the game channel whenever a player joins the game. 
 }
 ```
 
-<div class="ws-doc-table">
-
 |key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
 |:---               |:--- |
 |`type`             |String: The type of message being broadcast.|
@@ -316,8 +314,6 @@ This message is broadcast to the game channel whenever a player joins the game. 
 |`data.playerRoster`|Array: A collection of `player` objects for all players currently in the game, **ordered by** the time they joined the lobby.|
 |`-->player.id`     |Integer: The unique id of the given player.|
 |`-->player.name`   |String: The name of the given player.|
-
-</div>
 
 ---
 
@@ -351,7 +347,6 @@ This message is broadcast to the game channel once the final player has joined t
   }
 }
 ```
-<div class="ws-doc-table">
 
 |key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|description|
 |:---                  |:--- |
@@ -367,4 +362,49 @@ This message is broadcast to the game channel once the final player has joined t
 |`-->player.isIntel`   |Boolean: `true` if the player has the Intel role, `false` if they don't.|
 |`data.firstTeam`      |String: The team that will play first: "red" or "blue".|
 
-</div>
+---
+
+### Hint Sent
+
+This message is sent from the game client to the server by the current player. So long as the sender is the current player and has the Intel role, and the hint is a single-word string, this will generate a [Hint Provided](#hint-provided) broadcast to all players. If any of these requirements are not met, the appropriate [Illegal Action](#illegal-action) message will be broadcast instead.
+
+##### Call
+
+```js
+cable.sendHint({
+  hintWord: "tree",
+  numCards: 3
+})
+```
+
+|key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
+|:---      |:--- |
+|`hintWord`|String: A single word hint.|
+|`numCards`|Integer: The number of cards to which the hint is related.|
+
+---
+
+### Hint Provided
+
+This message is broadcast to all players after a valid [Hint Sent](#hint-sent) action is performed by a player. After receiving this message, play will proceed to the Spy player on the same team. The Spy will be allowed one more guess than the number of related cards.
+
+##### Payload
+
+```js
+{
+  type: 'hint-provided',
+  data: {
+    isBlueTeam: true,
+    hintWord: "tree",
+    relatedCards: 3
+  }
+}
+```
+
+|key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
+|:---               |:--- |
+|`type`             |String: The type of message being broadcast.|
+|`data`             |Object: The data payload of the message.|
+|`data.isBlueTeam`  |Boolean: Whether the hint belongs to the Blue team or not.|
+|`data.hintWord`    |String: The hint word provided by the player.|
+|`data.relatedCards`|Integer: The number of cards this hint is related to.|


### PR DESCRIPTION
# Description

Adds documentation to the README for the following websockets communications:
- Message from the client
  - Send Hint
  - Send Guess
- Broadcast from the server
  - Hint Provided
  - Board Update
  - Game Over
  - Illegal Message

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other, Please explain:
      Documentation only

## Has This Been Tested?

- [x] No
- [ ] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
- [ ] Have any prior tests been changed?
      If so, please explain:

# Checklist:

- [ ] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas