### PR TITLE
Bugfix: Change WS payload handling to assume string keys/values

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ This message is sent from the game client to the server by the current player. S
 ```js
 cable.sendHint({
   hintWord: "tree",
-  numCards: 3
+  numCards: "3"
 })
 ```
 
@@ -396,18 +396,20 @@ This message is broadcast to all players after a valid [Hint Sent](#hint-sent) a
   data: {
     isBlueTeam: true,
     hintWord: "tree",
-    relatedCards: 3
+    relatedCards: 3,
+    currentPlayerId: 1
   }
 }
 ```
 
 |key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
-|:---               |:--- |
-|`type`             |String: The type of message being broadcast.|
-|`data`             |Object: The data payload of the message.|
-|`data.isBlueTeam`  |Boolean: Whether the hint belongs to the Blue team or not.|
-|`data.hintWord`    |String: The hint word provided by the player.|
-|`data.relatedCards`|Integer: The number of cards this hint is related to.|
+|:---                  |:--- |
+|`type`                |String: The type of message being broadcast.|
+|`data`                |Object: The data payload of the message.|
+|`data.isBlueTeam`     |Boolean: Whether the hint belongs to the Blue team or not.|
+|`data.hintWord`       |String: The hint word provided by the player.|
+|`data.relatedCards`   |Integer: The number of cards this hint is related to.|
+|`data.currentPlayerId`|Integer: The ID of the new current player.|
 
 
 ---
@@ -420,7 +422,7 @@ This message is sent from the game client to the server by the current player. S
 
 ```js
 cable.sendGuess({
-  id: 1
+  id: "1"
 })
 ```
 
@@ -446,7 +448,7 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
       type: "red"
     },
     remainingAttempts: 2,
-    currentPlayer: 1
+    currentPlayerId: 1
   }
 }
 ```
@@ -460,7 +462,7 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
 |`-->card.flipped`       |Boolean: The flipped state of the card (always `true`).|
 |`-->card.type`          |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
 |`data.remainingAttempts`|Integer: The number of guesses remaining.|
-|`data.currentPlayer`    |Integer: The ID of the current player.|
+|`data.currentPlayerId`  |Integer: The ID of the current player.|
 
 ---
 

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -34,7 +34,8 @@ class GameDataChannel < ApplicationCable::Channel
         data: {
           isBlueTeam: saved_hint.blue?,
           hintWord: saved_hint.word,
-          relatedCards: saved_hint.num
+          relatedCards: saved_hint.num,
+          currentPlayerId: game.current_player.id
         }
       }
 
@@ -172,7 +173,7 @@ class GameDataChannel < ApplicationCable::Channel
             type: details[:card].category
           },
           remainingAttempts: details[:remainingAttempts],
-          currentPlayer: details[:currentPlayer].id
+          currentPlayerId: details[:currentPlayer].id
         }
       }
       broadcast_message payload

--- a/spec/channels/game_data_channel_guesses_spec.rb
+++ b/spec/channels/game_data_channel_guesses_spec.rb
@@ -25,7 +25,7 @@ describe GameDataChannel, type: :channel do
 
     guess_card = @game.game_cards.where(category: built_player.team).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -63,7 +63,7 @@ describe GameDataChannel, type: :channel do
 
     guess_card = @game.game_cards.where(category: @game.current_player.team).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -91,7 +91,7 @@ describe GameDataChannel, type: :channel do
 
     guess_card = @game.game_cards.where(category: built_player.team).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -155,7 +155,7 @@ describe GameDataChannel, type: :channel do
     opposing_team = built_player.blue? ? :red : :blue
     next_player = @game.players.where(team: opposing_team, role: :intel).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -191,7 +191,7 @@ describe GameDataChannel, type: :channel do
     opposing_team = built_player.blue? ? :red : :blue
     next_player = @game.players.where(team: opposing_team, role: :intel).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -227,7 +227,7 @@ describe GameDataChannel, type: :channel do
     guess_card = @game.game_cards.where(category: opposing_team).first
     next_player = @game.players.where(team: opposing_team, role: :intel).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -271,7 +271,7 @@ describe GameDataChannel, type: :channel do
     teammate = Player.where(game: @game, team: built_player.team).where.not(id: built_player.id).first
     teammate.update(role: :intel)
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -313,7 +313,7 @@ describe GameDataChannel, type: :channel do
     teammate = Player.where(game: @game, team: built_player.team).where.not(id: built_player.id).first
     teammate.update(role: :intel)
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -348,7 +348,7 @@ describe GameDataChannel, type: :channel do
     guess_card = @game.game_cards.where(category: :assassin).first
     next_player = @game.players.where(team: opposing_team, role: :intel).first
 
-    expect{subscription.send_guess(id: guess_card.id)}
+    expect{subscription.send_guess({"id" => "#{guess_card.id}"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once

--- a/spec/channels/game_data_channel_guesses_spec.rb
+++ b/spec/channels/game_data_channel_guesses_spec.rb
@@ -40,7 +40,7 @@ describe GameDataChannel, type: :channel do
         expect(received_card[:type]).to eq(guess_card.category)
 
         expect(payload[:remainingAttempts]).to eq(2)
-        expect(payload[:currentPlayer]).to eq(built_player.id)
+        expect(payload[:currentPlayerId]).to eq(built_player.id)
       }
 
     @game.reload
@@ -170,7 +170,7 @@ describe GameDataChannel, type: :channel do
         expect(received_card[:type]).to eq(guess_card.category)
 
         expect(payload[:remainingAttempts]).to eq(0)
-        expect(payload[:currentPlayer]).to eq(next_player.id)
+        expect(payload[:currentPlayerId]).to eq(next_player.id)
       }
   end
 
@@ -206,7 +206,7 @@ describe GameDataChannel, type: :channel do
         expect(received_card[:type]).to eq(guess_card.category)
 
         expect(payload[:remainingAttempts]).to eq(0)
-        expect(payload[:currentPlayer]).to eq(next_player.id)
+        expect(payload[:currentPlayerId]).to eq(next_player.id)
       }
   end
 
@@ -242,7 +242,7 @@ describe GameDataChannel, type: :channel do
         expect(received_card[:type]).to eq(guess_card.category)
 
         expect(payload[:remainingAttempts]).to eq(0)
-        expect(payload[:currentPlayer]).to eq(next_player.id)
+        expect(payload[:currentPlayerId]).to eq(next_player.id)
       }
   end
 

--- a/spec/channels/game_data_channel_hints_spec.rb
+++ b/spec/channels/game_data_channel_hints_spec.rb
@@ -22,7 +22,7 @@ describe GameDataChannel, type: :channel do
     teammate = Player.where(game: @game, team: built_player.team).where.not(id: built_player.id).first
     teammate.update(role: :spy)
 
-    expect{subscription.send_hint(hintWord: "Bob", numCards: 3)}
+    expect{subscription.send_hint({"hintWord" => "Bob", "numCards" => "3"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -53,7 +53,7 @@ describe GameDataChannel, type: :channel do
     @game.current_player = Player.where.not(id: intel.id).first
     @game.save
 
-    expect{subscription.send_hint(hintWord: "Bob", numCards: 3)}
+    expect{subscription.send_hint({"hintWord" => "Bob", "numCards" => "3"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -79,7 +79,7 @@ describe GameDataChannel, type: :channel do
     teammate = @game.players.where(team: random_player.team).where.not(id: random_player.id)
     teammate.update(role: :intel)
 
-    expect{subscription.send_hint(hintWord: "Bob", numCards: 3)}
+    expect{subscription.send_hint({"hintWord" => "Bob", "numCards" => "3"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once
@@ -105,7 +105,7 @@ describe GameDataChannel, type: :channel do
     teammate = @game.players.where(team: intel.team).where.not(id: intel.id)
     teammate.update(role: :spy)
 
-    expect{subscription.send_hint(hintWord: "Bob Loblaw", numCards: 3)}
+    expect{subscription.send_hint({"hintWord" => "Bob Loblaw", "numCards" => "3"})}
       .to have_broadcasted_to(@game)
       .from_channel(GameDataChannel)
       .once

--- a/spec/channels/game_data_channel_hints_spec.rb
+++ b/spec/channels/game_data_channel_hints_spec.rb
@@ -34,6 +34,7 @@ describe GameDataChannel, type: :channel do
         expect(payload).to have_key(:isBlueTeam)
         expect(payload).to have_key(:hintWord)
         expect(payload).to have_key(:relatedCards)
+        expect(payload).to have_key(:currentPlayerId)
       }
 
     @game.reload


### PR DESCRIPTION
# Description

Data payload sent by client contains an object with string keys and values like:
```js
{
  "hintWord" => "someword",
  "numCards" => "3"
}
```
Server code was set up based on the expectation that ActionCable would convert these like normal Rails controllers, but this turned out to be a bad assumption. Server code has been changed to accept the payloads in the form that they actually arrive.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      See below
- [x] Have any prior tests been changed?
      If so, please explain:
      Tests have been converted to send test data using the "stringy" form described above.

# Additional notes:

ActionCable. Delightful.

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas