### PR TITLE
Bugfix: Guessers can now end turn without using all guesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ This message is broadcast to all players after a valid [Hint Sent](#hint-sent) a
 
 This message is sent from the game client to the server by the current player. So long as the sender is the current player and has the Spy role, and the provided ID matches a card in the current game, this will generate a [Board Update](#board-update) broadcast to all players, unless the guess causes the game to end, in which case the [Game Over](#game-over) message will be broadcast instead. If any of these requirements are not met, the appropriate [Illegal Action](#illegal-action) message will be broadcast instead.
 
+If the Spy elects not to use all their guesses, they may pass. To convey a pass to the server, this message should be sent with `id: null`.
+
 ##### Call
 
 ```js
@@ -428,7 +430,7 @@ cable.sendGuess({
 
 |key&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|
 |:--- |:--- |
-|`id` |Integer: The ID of the guessed card.|
+|`id` |Integer: The ID of the guessed card, or `null` if player ends their guesses early.|
 
 ---
 
@@ -436,13 +438,15 @@ cable.sendGuess({
 
 This message is broadcast to all players after a valid [Guess Sent](#guess-sent) action is performed by a player, unless the guess causes the game to end (in which case, the [Game Over](#game-over) message will be broadcast instead). After receiving this message, play will proceed to the `currentPlayer` provided in the response.
 
+In the event that a Spy player decides to end their turn without taking all allowed guesses, the returned `card` will be `null` instead of an Object.
+
 ##### Payload
 
 ```js
 {
   type: 'board-update',
   data: {
-    card: {
+    card: { // {} or null
       id: 1,
       flipped: true,
       type: "red"
@@ -457,7 +461,7 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
 |:---                    |:--- |
 |`type`                  |String: The type of message being broadcast.|
 |`data`                  |Object: The data payload of the message.|
-|`data.card`             |Object: Data about the card that was guessed.|
+|`data.card`             |Object: Data about the card that was guessed, or `null` if the player has ended their turn without making all allowed guesses.|
 |`-->card.id`            |Integer: The ID of the guessed card.|
 |`-->card.flipped`       |Boolean: The flipped state of the card (always `true`).|
 |`-->card.type`          |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -113,6 +113,18 @@ class GameDataChannel < ApplicationCable::Channel
       end
     end
 
+    def compose_card(card)
+      if card
+        return {
+          id: card.id,
+          flipped: card.chosen,
+          type: card.category
+        }
+      else
+        return nil
+      end
+    end
+
     ##     ## ########  ######   ######     ###     ######   ########  ######
     ###   ### ##       ##    ## ##    ##   ## ##   ##    ##  ##       ##    ##
     #### #### ##       ##       ##        ##   ##  ##        ##       ##
@@ -164,14 +176,11 @@ class GameDataChannel < ApplicationCable::Channel
     end
 
     def board_update(details)
+      card = compose_card details[:card]
       payload = {
         type: "board-update",
         data: {
-          card: {
-            id: details[:card].id,
-            flipped: details[:card].chosen,
-            type: details[:card].category
-          },
+          card: card,
           remainingAttempts: details[:remainingAttempts],
           currentPlayerId: details[:currentPlayer].id
         }

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -52,10 +52,10 @@ class GameDataChannel < ApplicationCable::Channel
       illegal_action("#{current_player.name} attempted to submit a guess out of turn")
     elsif !current_player.spy?
       illegal_action("#{current_player.name} attempted to submit a guess, but doesn't have the Spy role")
-    elsif !game.includes_card?(card["id"].to_i)
+    elsif !game.includes_card?(card["id"])
       illegal_action("#{current_player.name} attempted to submit a guess for a card not in this game")
     else
-      contents = game.process_guess(card["id"].to_i)
+      contents = game.process_guess(card["id"])
       if game.over?
         game.save
         game_over contents

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -20,7 +20,7 @@ class Game < ApplicationRecord
     cp = self.current_player
     opposing_team = cp.red? ? :blue : :red
 
-    @turn_card = all_cards.find{|card| card.id == card_id}
+    @turn_card = all_cards.find{|card| card.id == card_id.to_i}
     @turn_card.update_attribute(:chosen, true)
     self.guesses.create(team: cp.team, game_card: @turn_card)
 
@@ -89,7 +89,7 @@ class Game < ApplicationRecord
 
   def includes_card?(id)
     card_ids = self.game_cards.pluck :id
-    card_ids.include? id
+    card_ids.include? id.to_i
   end
 
   private

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -20,6 +20,13 @@ class Game < ApplicationRecord
     cp = self.current_player
     opposing_team = cp.red? ? :blue : :red
 
+    # Handle Ending Guesses Early
+    if card_id == nil
+      @turn_card = nil
+      self.advance!
+      return guess_response
+    end
+
     @turn_card = all_cards.find{|card| card.id == card_id.to_i}
     @turn_card.update_attribute(:chosen, true)
     self.guesses.create(team: cp.team, game_card: @turn_card)
@@ -88,6 +95,7 @@ class Game < ApplicationRecord
   end
 
   def includes_card?(id)
+    return true if id == nil # player passed
     card_ids = self.game_cards.pluck :id
     card_ids.include? id.to_i
   end


### PR DESCRIPTION
# Description

Closes #46 

The game currently does not allow a Spy to end their turn before taking ALL allowed guesses. This is unintended behavior, as Spies should be allowed to end their turn at any time after taking their first guess.

This is the server side of a fix for this. It adds support for the UI's `sendGuess()` method to send a `null` card ID to indicate that the player is ending their turn. The server's response will be a `board-update` message with a `null` card as shown below:
![image](https://user-images.githubusercontent.com/3322920/61964798-fb1ff000-af8b-11e9-987b-762f92c8d80a.png)

README documentation has also been updated to indicate the new behaviors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [ ] No
- [x] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
      Added an additional test case to cover the described situation.
- [ ] Have any prior tests been changed?
      If so, please explain:

# Additional notes:
N/A

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas