### PR TITLE
Disconnect after game over

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,8 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
       flipped: true,
       type: "red"
     },
-    winningTeam: "red"
+    winningTeam: "red",
+    nextGame: "<invite code>"
   }
 }
 ```
@@ -499,6 +500,7 @@ This message is broadcast to all players after a valid [Guess Sent](#guess-sent)
 |`-->card.flipped` |Boolean: The flipped state of the card (always `true`).|
 |`-->card.type`    |String: The type of card to render in the UI: "red", "blue", "bystander", or "assassin".|
 |`data.winningTeam`|String: The team that won the game.|
+|`data.nextGame`   |String: An invite code for a new game. Provided automatically so all players can easily join the next game.|
 
 ---
 

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -10,7 +10,8 @@ module ApplicationCable
       def find_player
         #because there's no way to test the path_parameters
         token = request.path_parameters[:token] || request.params[:token]
-        if player = Player.find_by(token: token) && !player.game.over?
+        player = Player.find_by(token: token)
+        if player && !player.game.over?
           player
         else
           reject_unauthorized_connection

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -10,7 +10,7 @@ module ApplicationCable
       def find_player
         #because there's no way to test the path_parameters
         token = request.path_parameters[:token] || request.params[:token]
-        if player = Player.find_by(token: token)
+        if player = Player.find_by(token: token) && !player.game.over?
           player
         else
           reject_unauthorized_connection

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -3,8 +3,12 @@ class GameDataChannel < ApplicationCable::Channel
 
   def subscribed
     current_player.update(subscribed: true)
-    ensure_confirmation_sent
-    stream_for current_player.game
+    if current_player.game.over?
+      reject
+    else
+      ensure_confirmation_sent
+      stream_for current_player.game
+    end
   end
 
   def unsubscribed

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -12,7 +12,7 @@ class GameDataChannel < ApplicationCable::Channel
   end
 
   def unsubscribed
-    # Any cleanup needed when channel is unsubscribed
+    current_player.update(subscribed: false)
   end
 
   def send_hint(hint)

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -205,6 +205,7 @@ class GameDataChannel < ApplicationCable::Channel
         }
       }
       broadcast_message payload
+      disconnect_all_players(current_player.game)
     end
 
     ##     ## ######## ##       ########  ######## ########   ######
@@ -221,5 +222,11 @@ class GameDataChannel < ApplicationCable::Channel
 
     def all_players_in?(game)
       game.player_count == game.players.count{|p| p.subscribed?}
+    end
+
+    def disconnect_all_players(game)
+      game.players.each do |player|
+        ActionCable.server.remote_connections.where(current_player: player).disconnect
+      end
     end
 end

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -149,7 +149,7 @@ class GameDataChannel < ApplicationCable::Channel
     def start_game
       game = current_player.game
       game.reload
-      if all_players_in?(game)
+      if all_players_in?(game) && game.game_cards.count == 0
         game.establish!
 
         payload = {

--- a/app/channels/game_data_channel.rb
+++ b/app/channels/game_data_channel.rb
@@ -201,7 +201,8 @@ class GameDataChannel < ApplicationCable::Channel
             flipped: details[:card].chosen,
             type: details[:card].category
           },
-          winningTeam: details[:winningTeam]
+          winningTeam: details[:winningTeam],
+          nextGame: details[:nextGame]
         }
       }
       broadcast_message payload

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -218,6 +218,7 @@ class Game < ApplicationRecord
     end
 
     def gameover_response
+      self.update(current_player: nil)
       next_game = Game.create
       {
         card: @turn_card,

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -33,18 +33,18 @@ class Game < ApplicationRecord
 
     # Handle Gameover States
     if @turn_card.assassin?
-      @gameover = true
+      self.update(over: true)
       @winner = opposing_team
       return gameover_response
     else
       player_cards = all_cards.select{|card| card.category == cp.team}
       opposing_cards = all_cards.select{|card| card.category == opposing_team.to_s}
       if player_cards.all?{|card| card.chosen?}
-        @gameover = true
+        self.update(over: true)
         @winner = cp.team
         return gameover_response
       elsif opposing_cards.all?{|card| card.chosen?}
-        @gameover = true
+        self.update(over: true)
         @winner = opposing_team
         return gameover_response
       end
@@ -88,10 +88,6 @@ class Game < ApplicationRecord
 
   def full?
     users.size > 3
-  end
-
-  def over?
-    @gameover || false
   end
 
   def includes_card?(id)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -218,9 +218,11 @@ class Game < ApplicationRecord
     end
 
     def gameover_response
+      next_game = Game.create
       {
         card: @turn_card,
-        winningTeam: @winner
+        winningTeam: @winner,
+        nextGame: next_game.invite_code
       }
     end
 end

--- a/db/migrate/20190729021551_add_over_to_game.rb
+++ b/db/migrate/20190729021551_add_over_to_game.rb
@@ -1,0 +1,5 @@
+class AddOverToGame < ActiveRecord::Migration[5.2]
+  def change
+    add_column :games, :over, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_222815) do
+ActiveRecord::Schema.define(version: 2019_07_29_021551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,8 +38,9 @@ ActiveRecord::Schema.define(version: 2019_07_22_222815) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "player_count", default: 4
-    t.bigint "current_player_id"
+    t.integer "current_player_id"
     t.integer "guesses_remaining"
+    t.boolean "over", default: false
     t.index ["current_player_id"], name: "index_games_on_current_player_id"
     t.index ["invite_code"], name: "index_games_on_invite_code", unique: true
   end


### PR DESCRIPTION
# Description

Closes #45 

This PR covers a couple things:
- The `game-over` message now includes a `nextGame` key with an invite code for a new game. This allows to UI to provide a "play again" button to automatically bring players forward into the next game.
- Players are automatically disconnected from the Websockets channel once the game is over. Players are unable to connect to a game that has ended. This prevents the server from running unnecessarily long.
- Added a check to ensure that the game is only established once. In production, intermittent connection drops were triggering automatic reconnects. This is wonderful, however these also triggered the `subscribed` action on the server, which was re-establishing the game.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?

- [x] No
- [ ] Yes
      Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
- [ ] Have any prior tests been changed?
      If so, please explain:
      `Your message here`

# Additional notes:

No new tests have yet been written to cover sad path protections. Those will be backfilled in the next PR.

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas